### PR TITLE
Add `no-process-exit` rule

### DIFF
--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -1,0 +1,18 @@
+# Disallow `process.exit()`
+
+This rule is an extension to [ESLint's `no-process-exit`](http://eslint.org/docs/rules/no-process-exit) rule, that allows `process.exit()` to be called in files that start with a hashbang `#!/usr/bin/env node`.
+
+
+## Fail
+
+```js
+process.exit(0);
+```
+
+
+## Pass
+
+```js
+#!/usr/bin/env node
+process.exit(0);
+```

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
 	rules: {
+		'no-process-exit': require('./rules/no-process-exit'),
 		'throw-new-error': require('./rules/throw-new-error')
 	},
 	configs: {
@@ -14,6 +15,7 @@ module.exports = {
 				sourceType: 'module'
 			},
 			rules: {
+				'xo/no-process-exit': 'error',
 				'xo/throw-new-error': 'error'
 			}
 		}

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,8 @@ Configure it in `package.json`.
 			"xo"
 		],
 		"rules": {
-			"xo/throw-new-error": "error",
+			"xo/no-process-exit": "error",
+			"xo/throw-new-error": "error"
 		}
 	}
 }
@@ -40,6 +41,7 @@ Configure it in `package.json`.
 
 ## Rules
 
+- [no-process-exit](docs/rules/no-process-exit.md) - Disallow `process.exit()`.
 - [throw-new-error](docs/rules/throw-new-error.md) - Require `new` when throwing an error. *(fixable)*
 
 

--- a/rules/no-process-exit.js
+++ b/rules/no-process-exit.js
@@ -1,0 +1,20 @@
+'use strict';
+
+module.exports = function (context) {
+	var startsWithHashBang = context.getSourceCode().lines[0].indexOf('#!') === 0;
+	if (startsWithHashBang) {
+		return {};
+	}
+
+	return {
+		CallExpression: function (node) {
+			var callee = node.callee;
+
+			if (callee.type === 'MemberExpression' &&
+					callee.object.name === 'process' &&
+					callee.property.name === 'exit') {
+				context.report(node, 'Only use process.exit() in CLI apps. Throw an error instead.');
+			}
+		}
+	};
+};

--- a/test/no-process-exit.js
+++ b/test/no-process-exit.js
@@ -1,0 +1,41 @@
+import test from 'ava';
+import {RuleTester} from 'eslint';
+import rule from '../rules/no-process-exit';
+
+const ruleTester = new RuleTester({
+	env: {
+		es6: true
+	}
+});
+
+const errors = [{
+	ruleId: 'no-process-exit',
+	message: 'Only use process.exit() in CLI apps. Throw an error instead.',
+	type: 'CallExpression'
+}];
+
+test(() => {
+	ruleTester.run('no-process-exit', rule, {
+		valid: [
+			'Process.exit()',
+			'const exit = process.exit;',
+			'x(process.exit)',
+			'#!/usr/bin/env node\nprocess.exit(0);',
+			''
+		],
+		invalid: [
+			{
+				code: 'process.exit();',
+				errors
+			},
+			{
+				code: 'process.exit(1);',
+				errors
+			},
+			{
+				code: 'x(process.exit(1));',
+				errors
+			}
+		]
+	});
+});


### PR DESCRIPTION
Adds `no-process-exit` rule. Same as the ESLint core rule, but with the exception of files that start with a hasbang `#!`.

@sindresorhus asked me if I could implement this rule, and I thought it was fit to make a PR here.