### PR TITLE
Add `PascalCase` option to the `filename-case` rule

### DIFF
--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -21,7 +21,7 @@ Enforces all linted files to have their names in a certain case style. Default i
 - `foo_bar.test.js`
 - `foo_bar.test_utils.js`
 
-### `PascalCase`
+### `pascalCase`
 
 - `FooBar.js`
 - `FooBar.Test.js`

--- a/docs/rules/filename-case.md
+++ b/docs/rules/filename-case.md
@@ -21,6 +21,12 @@ Enforces all linted files to have their names in a certain case style. Default i
 - `foo_bar.test.js`
 - `foo_bar.test_utils.js`
 
+### `PascalCase`
+
+- `FooBar.js`
+- `FooBar.Test.js`
+- `FooBar.TestUtils.js`
+
 
 ## Options
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "lodash.camelcase": "^4.1.1",
     "lodash.kebabcase": "^4.0.1",
     "lodash.snakecase": "^4.0.1",
-    "pascal-case": "^1.1.2"
+    "lodash.upperfirst": "^4.2.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "dependencies": {
     "lodash.camelcase": "^4.1.1",
     "lodash.kebabcase": "^4.0.1",
-    "lodash.snakecase": "^4.0.1"
+    "lodash.snakecase": "^4.0.1",
+    "pascal-case": "^1.1.2"
   },
   "devDependencies": {
     "ava": "*",

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -3,7 +3,11 @@ var path = require('path');
 var camelCase = require('lodash.camelcase');
 var kebabCase = require('lodash.kebabcase');
 var snakeCase = require('lodash.snakecase');
-var pascalCase = require('pascal-case');
+var upperfirst = require('lodash.upperfirst');
+
+var pascalCase = function (str) {
+	return upperfirst(camelCase(str));
+};
 
 var cases = {
 	camelCase: {

--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -3,6 +3,7 @@ var path = require('path');
 var camelCase = require('lodash.camelcase');
 var kebabCase = require('lodash.kebabcase');
 var snakeCase = require('lodash.snakecase');
+var pascalCase = require('pascal-case');
 
 var cases = {
 	camelCase: {
@@ -16,6 +17,10 @@ var cases = {
 	snakeCase: {
 		fn: snakeCase,
 		name: 'snake case'
+	},
+	pascalCase: {
+		fn: pascalCase,
+		name: 'pascal case'
 	}
 };
 
@@ -53,7 +58,8 @@ module.exports.schema = [{
 			enum: [
 				'camelCase',
 				'snakeCase',
-				'kebabCase'
+				'kebabCase',
+				'pascalCase'
 			]
 		}
 	}

--- a/test/filename-case.js
+++ b/test/filename-case.js
@@ -37,7 +37,12 @@ test(() => {
 			testCase('src/foo/foo-bar.js', 'kebabCase'),
 			testCase('src/foo/foo.test.js', 'kebabCase'),
 			testCase('src/foo/foo-bar.test.js', 'kebabCase'),
-			testCase('src/foo/foo-bar.test-utils.js', 'kebabCase')
+			testCase('src/foo/foo-bar.test-utils.js', 'kebabCase'),
+			testCase('src/foo/Foo.js', 'pascalCase'),
+			testCase('src/foo/FooBar.js', 'pascalCase'),
+			testCase('src/foo/Foo.Test.js', 'pascalCase'),
+			testCase('src/foo/FooBar.Test.js', 'pascalCase'),
+			testCase('src/foo/FooBar.TestUtils.js', 'pascalCase')
 		],
 		invalid: [
 			testCase('src/foo/foo_bar.js',
@@ -79,6 +84,18 @@ test(() => {
 			testCase('test/foo/fooBar.testUtils.js',
 				'kebabCase',
 				'Filename is not in kebab case. Rename it to `foo-bar.test-utils.js`.'
+			),
+			testCase('test/foo/fooBar.js',
+				'pascalCase',
+				'Filename is not in pascal case. Rename it to `FooBar.js`.'
+			),
+			testCase('test/foo/foo_bar.test.js',
+				'pascalCase',
+				'Filename is not in pascal case. Rename it to `FooBar.Test.js`.'
+			),
+			testCase('test/foo/foo-bar.test-utils.js',
+				'pascalCase',
+				'Filename is not in pascal case. Rename it to `FooBar.TestUtils.js`.'
 			)
 		]
 	});


### PR DESCRIPTION
Hello,

I need to use **PascalCase** for one of my projects and I thought it'd be nice to have it in this repo. I know that there're tons of people who uses PascalCase for their class names or model names, etc. So yea, I hope it'll help. 

```bash
$ npm test

> eslint-plugin-xo@0.3.1 test /Users/gokaygurcan/Projects/GitHub/eslint-plugin-xo
> xo && nyc ava


   4 passed
----------------------|----------|----------|----------|----------|----------------|
File                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------------------|----------|----------|----------|----------|----------------|
 rules/               |    95.38 |     87.5 |      100 |    95.38 |                |
  catch-error-name.js |    90.32 |       80 |      100 |    90.32 |        8,14,18 |
  filename-case.js    |      100 |      100 |      100 |      100 |                |
  no-process-exit.js  |      100 |      100 |      100 |      100 |                |
  throw-new-error.js  |      100 |      100 |      100 |      100 |                |
----------------------|----------|----------|----------|----------|----------------|
All files             |    95.38 |     87.5 |      100 |    95.38 |                |
----------------------|----------|----------|----------|----------|----------------|
```