### PR TITLE
Handle linting from text in `filename-case`. Fixes #19

### DIFF
--- a/rules/filename-case.js
+++ b/rules/filename-case.js
@@ -37,10 +37,14 @@ function fixFilename(chosenCase, filename) {
 
 module.exports = function (context) {
 	var chosenCase = cases[context.options[0].case || 'camelCase'];
+	var filenameWithExt = context.getFilename();
+
+	if (filenameWithExt === '<text>') {
+		return {};
+	}
 
 	return {
 		Program: function (node) {
-			var filenameWithExt = context.getFilename();
 			var extension = path.extname(filenameWithExt);
 			var filename = path.basename(filenameWithExt, extension);
 			var fixedFilename = fixFilename(chosenCase, filename);

--- a/test/filename-case.js
+++ b/test/filename-case.js
@@ -42,7 +42,11 @@ test(() => {
 			testCase('src/foo/FooBar.js', 'pascalCase'),
 			testCase('src/foo/Foo.Test.js', 'pascalCase'),
 			testCase('src/foo/FooBar.Test.js', 'pascalCase'),
-			testCase('src/foo/FooBar.TestUtils.js', 'pascalCase')
+			testCase('src/foo/FooBar.TestUtils.js', 'pascalCase'),
+			testCase('<text>', 'camelCase'),
+			testCase('<text>', 'snakeCase'),
+			testCase('<text>', 'kebabCase'),
+			testCase('<text>', 'pascalCase')
 		],
 		invalid: [
 			testCase('src/foo/foo_bar.js',


### PR DESCRIPTION
Handle linting from text in `filename-case`. Fixes #19