### PR TITLE
Add `no-abusive-eslint-disable` rule

### DIFF
--- a/docs/rules/no-abusive-eslint-disable.md
+++ b/docs/rules/no-abusive-eslint-disable.md
@@ -1,4 +1,4 @@
-# Enforce specifying exact rules to disable in `eslint-disable` comments
+# Enforce specifying rules to disable in `eslint-disable` comments
 
 This rule enforces you to specify the rules you want to disable when using `eslint-disable` or `eslint-disable-line` comments.
 

--- a/docs/rules/no-abusive-eslint-disable.md
+++ b/docs/rules/no-abusive-eslint-disable.md
@@ -1,16 +1,18 @@
-# Specify rules to disable when using `eslint-disable` comments
+# Enforce specifying exact rules to disable in `eslint-disable` comments
 
-If you want to disable a ESLint rule in a file or on a specific line, you can add a comment like:
+This rule enforces you to specify the rules you want to disable when using `eslint-disable` or `eslint-disable-line` comments.
 
-On a single line
+If you want to disable an ESLint rule in a file or on a specific line, you can add a comment like:
+
+On a single line:
 ```js
-var message = 'foo';
+const message = 'foo';
 console.log(message); // eslint-disable-line no-console
 ```
-On the whole (rest of the) file
+On the whole (rest of the) file:
 ```js
 /* eslint-disable no-console */
-var message = 'foo';
+const message = 'foo';
 console.log(message);
 ```
 
@@ -21,7 +23,7 @@ You don't have to specify any rules (like `no-console` in the examples above), b
 console.log(message); // `message` is not defined, but it won't be reported
 ```
 
-This rule enforces the specification of rules to disable. If you want to disable ESLint on a file altogether, you should ignore it through [`.eslintignore`](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories).
+This rule enforces the specification of rules to disable. If you want to disable ESLint on a file altogether, you should ignore it through [`.eslintignore`](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories) for ESLint or through the `ignore` property in the `package.json` file for `XO`.
 
 ## Fail
 

--- a/docs/rules/no-abusive-eslint-disable.md
+++ b/docs/rules/no-abusive-eslint-disable.md
@@ -1,0 +1,43 @@
+# Specify rules to disable when using `eslint-disable` comments
+
+If you want to disable a ESLint rule in a file or on a specific line, you can add a comment like:
+
+On a single line
+```js
+var message = 'foo';
+console.log(message); // eslint-disable-line no-console
+```
+On the whole (rest of the) file
+```js
+/* eslint-disable no-console */
+var message = 'foo';
+console.log(message);
+```
+
+You don't have to specify any rules (like `no-console` in the examples above), but you should, as you might otherwise hide useful errors.
+
+```js
+/* eslint-disable */
+console.log(message); // `message` is not defined, but it won't be reported
+```
+
+This rule enforces the specification of rules to disable. If you want to disable ESLint on a file altogether, you should ignore it through [`.eslintignore`](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories).
+
+## Fail
+
+```js
+/* eslint-disable */
+console.log(message);
+
+console.log(message); // eslint-disable-line
+```
+
+
+## Pass
+
+```js
+/* eslint-disable no-console */
+console.log(message);
+
+console.log(message); // eslint-disable-line no-console
+```

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ module.exports = {
 	rules: {
 		'catch-error-name': require('./rules/catch-error-name'),
 		'filename-case': require('./rules/filename-case'),
+		'no-abusive-eslint-disable': require('./rules/no-abusive-eslint-disable'),
 		'no-process-exit': require('./rules/no-process-exit'),
 		'throw-new-error': require('./rules/throw-new-error')
 	},
@@ -19,6 +20,7 @@ module.exports = {
 			rules: {
 				'xo/catch-error-name': ['error', {name: 'err'}],
 				'xo/filename-case': ['error', {case: 'kebabCase'}],
+				'xo/no-abusive-eslint-disable': 'error',
 				'xo/no-process-exit': 'error',
 				'xo/throw-new-error': 'error'
 			}

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Configure it in `package.json`.
 
 - [catch-error-name](docs/rules/catch-error-name.md) - Enforce a specific parameter name in catch clauses.
 - [filename-case](docs/rules/filename-case.md) - Enforce a case style for filenames.
-- [no-abusive-eslint-disable](docs/rules/no-abusive-eslint-disable.md) - Specify rules to disable when using `eslint-disable` comments
+- [no-abusive-eslint-disable](docs/rules/no-abusive-eslint-disable.md) - Enforce specifying exact rules to disable in `eslint-disable` comments.
 - [no-process-exit](docs/rules/no-process-exit.md) - Disallow `process.exit()`.
 - [throw-new-error](docs/rules/throw-new-error.md) - Require `new` when throwing an error. *(fixable)*
 

--- a/readme.md
+++ b/readme.md
@@ -33,6 +33,7 @@ Configure it in `package.json`.
 		"rules": {
 			"xo/catch-error-name": ["error", {"name": "err"}],
 			"xo/filename-case": ["error", {"case": "kebabCase"}],
+			"xo/no-abusive-eslint-disable": "error",
 			"xo/no-process-exit": "error",
 			"xo/throw-new-error": "error"
 		}
@@ -45,6 +46,7 @@ Configure it in `package.json`.
 
 - [catch-error-name](docs/rules/catch-error-name.md) - Enforce a specific parameter name in catch clauses.
 - [filename-case](docs/rules/filename-case.md) - Enforce a case style for filenames.
+- [no-abusive-eslint-disable](docs/rules/no-abusive-eslint-disable.md) - Specify rules to disable when using `eslint-disable` comments
 - [no-process-exit](docs/rules/no-process-exit.md) - Disallow `process.exit()`.
 - [throw-new-error](docs/rules/throw-new-error.md) - Require `new` when throwing an error. *(fixable)*
 

--- a/readme.md
+++ b/readme.md
@@ -46,7 +46,7 @@ Configure it in `package.json`.
 
 - [catch-error-name](docs/rules/catch-error-name.md) - Enforce a specific parameter name in catch clauses.
 - [filename-case](docs/rules/filename-case.md) - Enforce a case style for filenames.
-- [no-abusive-eslint-disable](docs/rules/no-abusive-eslint-disable.md) - Enforce specifying exact rules to disable in `eslint-disable` comments.
+- [no-abusive-eslint-disable](docs/rules/no-abusive-eslint-disable.md) - Enforce specifying rules to disable in `eslint-disable` comments.
 - [no-process-exit](docs/rules/no-process-exit.md) - Disallow `process.exit()`.
 - [throw-new-error](docs/rules/throw-new-error.md) - Require `new` when throwing an error. *(fixable)*
 

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -16,7 +16,7 @@ module.exports = function (context) {
 						// will be ignored due to the disable comment
 						loc: {line: 0, column: 0},
 						// So specify it in the message
-						message: 'Specify the exact rules you want to disable at line {{line}}:{{column}}',
+						message: 'Specify the rules you want to disable at line {{line}}:{{column}}',
 						data: comment.loc.start
 					});
 				}

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -16,7 +16,7 @@ module.exports = function (context) {
 						// will be ignored due to the disable comment
 						loc: {line: 0, column: 0},
 						// So specify it in the message
-						message: 'Specify the rule(s) you want to disable at line {{line}}:{{column}}',
+						message: 'Specify the exact rules you want to disable at line {{line}}:{{column}}',
 						data: comment.loc.start
 					});
 				}

--- a/rules/no-abusive-eslint-disable.js
+++ b/rules/no-abusive-eslint-disable.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var disableRegex = /^eslint-disable(-line)?(\s+([\w-]+))?/;
+
+module.exports = function (context) {
+	return {
+		Program: function (node) {
+			node.comments.forEach(function (comment) {
+				var value = comment.value.trim();
+				var res = disableRegex.exec(value);
+				if (res && // It is a eslint-disable comment
+					!res[2] // but it did not specify any rules
+				) {
+					context.report({
+						// Can't set it at the given location as the warning
+						// will be ignored due to the disable comment
+						loc: {line: 0, column: 0},
+						// So specify it in the message
+						message: 'Specify the rule(s) you want to disable at line {{line}}:{{column}}',
+						data: comment.loc.start
+					});
+				}
+			});
+		}
+	};
+};

--- a/test/no-abusive-eslint-disable.js
+++ b/test/no-abusive-eslint-disable.js
@@ -1,0 +1,56 @@
+import test from 'ava';
+import {RuleTester} from 'eslint';
+import rule from '../rules/no-abusive-eslint-disable';
+
+const ruleTester = new RuleTester({
+	env: {
+		es6: true
+	}
+});
+
+const error = (message) => ({
+	ruleId: 'no-abusive-eslint-disable',
+	message
+});
+
+test(() => {
+	ruleTester.run('no-abusive-eslint-disable', rule, {
+		valid: [
+			`eval();`,
+			`eval(); // eslint-disable-line no-eval`,
+			`eval(); // eslint-disable-line no-eval, no-console`,
+			`eval(); //eslint-disable-line no-eval`,
+			`eval(); //     eslint-disable-line no-eval`,
+			`eval(); //\teslint-disable-line no-eval`,
+			`eval(); /* eslint-disable-line no-eval */`,
+			`eval(); /* eslint-disable-line no-eval */`,
+			`eval(); // eslint-line-disable`,
+			`eval(); // some comment`,
+			`foo();
+			// eslint-disable-line no-eval
+			eval();`,
+			'/* eslint-disable no-eval */',
+			`foo();
+			/* eslint-disable no-eval */
+			eval();`
+		],
+		invalid: [
+			{
+				code: `eval(); // eslint-disable-line`,
+				errors: [error('Specify the rule(s) you want to disable at line 1:8')]
+			},
+			{
+				code: 'foo();\neval(); // eslint-disable-line',
+				errors: [error('Specify the rule(s) you want to disable at line 2:8')]
+			},
+			{
+				code: '/* eslint-disable */',
+				errors: [error('Specify the rule(s) you want to disable at line 1:0')]
+			},
+			{
+				code: 'foo();\n/* eslint-disable */\neval();',
+				errors: [error('Specify the rule(s) you want to disable at line 2:0')]
+			}
+		]
+	});
+});

--- a/test/no-abusive-eslint-disable.js
+++ b/test/no-abusive-eslint-disable.js
@@ -37,19 +37,19 @@ test(() => {
 		invalid: [
 			{
 				code: `eval(); // eslint-disable-line`,
-				errors: [error('Specify the exact rules you want to disable at line 1:8')]
+				errors: [error('Specify the rules you want to disable at line 1:8')]
 			},
 			{
 				code: 'foo();\neval(); // eslint-disable-line',
-				errors: [error('Specify the exact rules you want to disable at line 2:8')]
+				errors: [error('Specify the rules you want to disable at line 2:8')]
 			},
 			{
 				code: '/* eslint-disable */',
-				errors: [error('Specify the exact rules you want to disable at line 1:0')]
+				errors: [error('Specify the rules you want to disable at line 1:0')]
 			},
 			{
 				code: 'foo();\n/* eslint-disable */\neval();',
-				errors: [error('Specify the exact rules you want to disable at line 2:0')]
+				errors: [error('Specify the rules you want to disable at line 2:0')]
 			}
 		]
 	});

--- a/test/no-abusive-eslint-disable.js
+++ b/test/no-abusive-eslint-disable.js
@@ -37,19 +37,19 @@ test(() => {
 		invalid: [
 			{
 				code: `eval(); // eslint-disable-line`,
-				errors: [error('Specify the rule(s) you want to disable at line 1:8')]
+				errors: [error('Specify the exact rules you want to disable at line 1:8')]
 			},
 			{
 				code: 'foo();\neval(); // eslint-disable-line',
-				errors: [error('Specify the rule(s) you want to disable at line 2:8')]
+				errors: [error('Specify the exact rules you want to disable at line 2:8')]
 			},
 			{
 				code: '/* eslint-disable */',
-				errors: [error('Specify the rule(s) you want to disable at line 1:0')]
+				errors: [error('Specify the exact rules you want to disable at line 1:0')]
 			},
 			{
 				code: 'foo();\n/* eslint-disable */\neval();',
-				errors: [error('Specify the rule(s) you want to disable at line 2:0')]
+				errors: [error('Specify the exact rules you want to disable at line 2:0')]
 			}
 		]
 	});


### PR DESCRIPTION
This is a rule proposal, but as I wanted to know whether it was actually possible, I *accidentally* went all the way :p

I saw [this message](https://gitter.im/eslint/eslint?at=5751c0393bdac7ae37b46224) by @alanhussey on the ESLint Gitter, and thought it was a pretty good idea.

The proposal is to enforce specifying the rules to disable when you use `eslint-disable`/`eslint-disable-line`, as you can otherwise hide some useful error reports.

Let me know what you think :)