### PR TITLE
Allow `no-process-exit` to be used in process event handlers (fixes #32)

### DIFF
--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -1,6 +1,6 @@
 # Disallow `process.exit()`
 
-This rule is an extension to ESLint's [`no-process-exit` rule](http://eslint.org/docs/rules/no-process-exit), that allows `process.exit()` to be called in files that start with a [hashbang](https://en.wikipedia.org/wiki/Shebang_(Unix)) → `#!/usr/bin/env node`.
+This rule is an extension to ESLint's [`no-process-exit` rule](http://eslint.org/docs/rules/no-process-exit), that allows `process.exit()` to be called in files that start with a [hashbang](https://en.wikipedia.org/wiki/Shebang_(Unix)) → `#!/usr/bin/env node`. It also allows `process.exit()` to be called in `process.on('<event>', func)` event handlers.
 
 
 ## Fail
@@ -15,4 +15,11 @@ process.exit(0);
 ```js
 #!/usr/bin/env node
 process.exit(0);
+```
+
+```js
+process.on('SIGINT', () => {
+    console.log('Got SIGINT');
+    process.exit(1);
+});
 ```

--- a/test/no-process-exit.js
+++ b/test/no-process-exit.js
@@ -8,7 +8,10 @@ const ruleTester = avaRuleTester(test, {
 	}
 });
 
-const errors = [{ruleId: 'no-process-exit'}];
+const errors = [{
+	ruleId: 'no-process-exit',
+	message: 'Only use `process.exit()` in CLI apps. Throw an error instead.'
+}];
 
 ruleTester.run('no-process-exit', rule, {
 	valid: [
@@ -16,6 +19,11 @@ ruleTester.run('no-process-exit', rule, {
 		'Process.exit()',
 		'const x = process.exit;',
 		'x(process.exit)',
+		'process.on("SIGINT", function() { process.exit(1); })',
+		'process.on("SIGKILL", function() { process.exit(1); })',
+		'process.on("SIGINT", () => { process.exit(1); })',
+		'process.on("SIGINT", () => process.exit(1))',
+		'process.on("SIGINT", () => { if (true) { process.exit(1); } })',
 		''
 	],
 	invalid: [


### PR DESCRIPTION
Allow `no-process-exit` to be used in process event handlers (fixes #32)

I think that we should probably change the error message to mention it can be used in `process.on(...)`, but not sure. I don't want to invite people to use it everywhere, and the message would be pretty long. What do you think?